### PR TITLE
This PR addresses issue #9 by adapting the contacts plugin for use on Obsidian Mobile.

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -11,35 +11,34 @@ if you want to view the source, please visit the github repository of this plugi
 const prod = process.argv[2] === "production";
 
 esbuild
-	.build({
-		banner: {
-			js: banner,
-		},
-		entryPoints: ["src/main.ts"],
-		bundle: true,
-		external: [
-			"obsidian",
-			"electron",
-			"@codemirror/autocomplete",
-			"@codemirror/collab",
-			"@codemirror/commands",
-			"@codemirror/language",
-			"@codemirror/lint",
-			"@codemirror/search",
-			"@codemirror/state",
-			"@codemirror/view",
-			"@lezer/common",
-			"@lezer/highlight",
-			"@lezer/lr",
-			...builtins,
-		],
-		format: "cjs",
-		watch: !prod,
-		target: "es2018",
-		logLevel: "info",
-		sourcemap: prod ? false : "inline",
-		treeShaking: true,
-		minify: true,
-		outfile: "main.js",
-	})
-	.catch(() => process.exit(1));
+  .build({
+    banner: {
+      js: banner,
+    },
+    entryPoints: ["src/main.ts"],
+    bundle: true,
+    external: [
+      "obsidian",
+      "electron",
+      "@codemirror/autocomplete",
+      "@codemirror/collab",
+      "@codemirror/commands",
+      "@codemirror/language",
+      "@codemirror/lint",
+      "@codemirror/search",
+      "@codemirror/state",
+      "@codemirror/view",
+      "@lezer/common",
+      "@lezer/highlight",
+      "@lezer/lr",
+      ...builtins,
+    ],
+    format: "cjs",
+    target: "es2022",
+    logLevel: "info",
+    sourcemap: prod ? false : "inline",
+    treeShaking: true,
+    minify: true,
+    outfile: "main.js",
+  })
+  .catch(() => process.exit(1));

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,6 @@
 	"description": "Effortlessly manage, organize, and interact with your contacts. Import, export, and structure vCard (VCF) files seamlessly while keeping all contact details accessible in your knowledge base. Includes click-to-call, right-click copy, structured metadata, and more!",
 	"author": "Roland Broekema",
 	"authorUrl": "https://github.com/broekema41/",
-	"isDesktopOnly": true,
+	"isDesktopOnly": false,
   "forkedFrom": "https://github.com/vbeskrovnov/obsidian-contacts/"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,25 @@
 {
 	"name": "vcf-contacts",
-	"version": "2.0.1",
+	"version": "2.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vcf-contacts",
-			"version": "2.0.1",
+			"version": "2.0.3",
 			"license": "MIT",
 			"dependencies": {
-				"js-yaml": "^4.1.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0"
 			},
 			"devDependencies": {
-				"@types/js-yaml": "^4.0.9",
 				"@types/node": "^16.11.6",
 				"@types/react": "^18.0.26",
 				"@types/react-dom": "^18.0.9",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
-				"esbuild": "0.14.47",
+				"esbuild": "^0.25.2",
 				"eslint-plugin-import": "^2.31.0",
 				"eslint-plugin-simple-import-sort": "^12.1.1",
 				"obsidian": "latest",
@@ -46,6 +44,406 @@
 				"@codemirror/state": "^6.1.4",
 				"style-mod": "^4.0.0",
 				"w3c-keyname": "^2.2.4"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
+			"integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz",
+			"integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz",
+			"integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz",
+			"integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz",
+			"integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
+			"integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
+			"integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz",
+			"integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz",
+			"integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz",
+			"integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz",
+			"integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz",
+			"integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz",
+			"integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz",
+			"integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz",
+			"integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz",
+			"integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz",
+			"integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
+			"integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz",
+			"integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
+			"integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz",
+			"integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz",
+			"integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz",
+			"integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz",
+			"integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz",
+			"integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -162,12 +560,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
 			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
-			"dev": true
-		},
-		"node_modules/@types/js-yaml": {
-			"version": "4.0.9",
-			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-			"integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
 			"dev": true
 		},
 		"node_modules/@types/json-schema": {
@@ -482,7 +874,9 @@
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/array-buffer-byte-length": {
 			"version": "1.0.2",
@@ -648,12 +1042,12 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -772,9 +1166,9 @@
 			"dev": true
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -1080,358 +1474,43 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.47.tgz",
-			"integrity": "sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
+			"integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"esbuild-android-64": "0.14.47",
-				"esbuild-android-arm64": "0.14.47",
-				"esbuild-darwin-64": "0.14.47",
-				"esbuild-darwin-arm64": "0.14.47",
-				"esbuild-freebsd-64": "0.14.47",
-				"esbuild-freebsd-arm64": "0.14.47",
-				"esbuild-linux-32": "0.14.47",
-				"esbuild-linux-64": "0.14.47",
-				"esbuild-linux-arm": "0.14.47",
-				"esbuild-linux-arm64": "0.14.47",
-				"esbuild-linux-mips64le": "0.14.47",
-				"esbuild-linux-ppc64le": "0.14.47",
-				"esbuild-linux-riscv64": "0.14.47",
-				"esbuild-linux-s390x": "0.14.47",
-				"esbuild-netbsd-64": "0.14.47",
-				"esbuild-openbsd-64": "0.14.47",
-				"esbuild-sunos-64": "0.14.47",
-				"esbuild-windows-32": "0.14.47",
-				"esbuild-windows-64": "0.14.47",
-				"esbuild-windows-arm64": "0.14.47"
-			}
-		},
-		"node_modules/esbuild-android-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.47.tgz",
-			"integrity": "sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-android-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.47.tgz",
-			"integrity": "sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-darwin-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.47.tgz",
-			"integrity": "sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-darwin-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.47.tgz",
-			"integrity": "sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-freebsd-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.47.tgz",
-			"integrity": "sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-freebsd-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.47.tgz",
-			"integrity": "sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-32": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.47.tgz",
-			"integrity": "sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.47.tgz",
-			"integrity": "sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-arm": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.47.tgz",
-			"integrity": "sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.47.tgz",
-			"integrity": "sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-mips64le": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.47.tgz",
-			"integrity": "sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-ppc64le": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.47.tgz",
-			"integrity": "sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-riscv64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.47.tgz",
-			"integrity": "sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-s390x": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.47.tgz",
-			"integrity": "sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-netbsd-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.47.tgz",
-			"integrity": "sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-openbsd-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz",
-			"integrity": "sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-sunos-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz",
-			"integrity": "sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-windows-32": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.47.tgz",
-			"integrity": "sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-windows-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.47.tgz",
-			"integrity": "sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-windows-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.47.tgz",
-			"integrity": "sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
+				"@esbuild/aix-ppc64": "0.25.2",
+				"@esbuild/android-arm": "0.25.2",
+				"@esbuild/android-arm64": "0.25.2",
+				"@esbuild/android-x64": "0.25.2",
+				"@esbuild/darwin-arm64": "0.25.2",
+				"@esbuild/darwin-x64": "0.25.2",
+				"@esbuild/freebsd-arm64": "0.25.2",
+				"@esbuild/freebsd-x64": "0.25.2",
+				"@esbuild/linux-arm": "0.25.2",
+				"@esbuild/linux-arm64": "0.25.2",
+				"@esbuild/linux-ia32": "0.25.2",
+				"@esbuild/linux-loong64": "0.25.2",
+				"@esbuild/linux-mips64el": "0.25.2",
+				"@esbuild/linux-ppc64": "0.25.2",
+				"@esbuild/linux-riscv64": "0.25.2",
+				"@esbuild/linux-s390x": "0.25.2",
+				"@esbuild/linux-x64": "0.25.2",
+				"@esbuild/netbsd-arm64": "0.25.2",
+				"@esbuild/netbsd-x64": "0.25.2",
+				"@esbuild/openbsd-arm64": "0.25.2",
+				"@esbuild/openbsd-x64": "0.25.2",
+				"@esbuild/sunos-x64": "0.25.2",
+				"@esbuild/win32-arm64": "0.25.2",
+				"@esbuild/win32-ia32": "0.25.2",
+				"@esbuild/win32-x64": "0.25.2"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -1847,9 +1926,9 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -2674,6 +2753,8 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -2755,18 +2836,6 @@
 				"loose-envify": "cli.js"
 			}
 		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2786,12 +2855,12 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -3359,13 +3428,10 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -3954,9 +4020,9 @@
 			}
 		},
 		"node_modules/word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
 			"peer": true,
 			"engines": {
@@ -3969,12 +4035,6 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
@@ -4009,6 +4069,181 @@
 				"style-mod": "^4.0.0",
 				"w3c-keyname": "^2.2.4"
 			}
+		},
+		"@esbuild/aix-ppc64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
+			"integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/android-arm": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz",
+			"integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/android-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz",
+			"integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/android-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz",
+			"integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/darwin-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz",
+			"integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/darwin-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
+			"integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/freebsd-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
+			"integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/freebsd-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz",
+			"integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-arm": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz",
+			"integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz",
+			"integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-ia32": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz",
+			"integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-loong64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz",
+			"integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-mips64el": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz",
+			"integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-ppc64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz",
+			"integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-riscv64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz",
+			"integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-s390x": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz",
+			"integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz",
+			"integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/netbsd-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
+			"integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/netbsd-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz",
+			"integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/openbsd-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
+			"integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/openbsd-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz",
+			"integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/sunos-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz",
+			"integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/win32-arm64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz",
+			"integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/win32-ia32": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz",
+			"integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/win32-x64": {
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz",
+			"integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
+			"dev": true,
+			"optional": true
 		},
 		"@eslint/eslintrc": {
 			"version": "1.3.3",
@@ -4099,12 +4334,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
 			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
-			"dev": true
-		},
-		"@types/js-yaml": {
-			"version": "4.0.9",
-			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-			"integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
 			"dev": true
 		},
 		"@types/json-schema": {
@@ -4309,7 +4538,9 @@
 		"argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"peer": true
 		},
 		"array-buffer-byte-length": {
 			"version": "1.0.2",
@@ -4427,12 +4658,12 @@
 			}
 		},
 		"braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"requires": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			}
 		},
 		"builtin-modules": {
@@ -4515,9 +4746,9 @@
 			"dev": true
 		},
 		"cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -4746,172 +4977,37 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.47.tgz",
-			"integrity": "sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
+			"integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
 			"dev": true,
 			"requires": {
-				"esbuild-android-64": "0.14.47",
-				"esbuild-android-arm64": "0.14.47",
-				"esbuild-darwin-64": "0.14.47",
-				"esbuild-darwin-arm64": "0.14.47",
-				"esbuild-freebsd-64": "0.14.47",
-				"esbuild-freebsd-arm64": "0.14.47",
-				"esbuild-linux-32": "0.14.47",
-				"esbuild-linux-64": "0.14.47",
-				"esbuild-linux-arm": "0.14.47",
-				"esbuild-linux-arm64": "0.14.47",
-				"esbuild-linux-mips64le": "0.14.47",
-				"esbuild-linux-ppc64le": "0.14.47",
-				"esbuild-linux-riscv64": "0.14.47",
-				"esbuild-linux-s390x": "0.14.47",
-				"esbuild-netbsd-64": "0.14.47",
-				"esbuild-openbsd-64": "0.14.47",
-				"esbuild-sunos-64": "0.14.47",
-				"esbuild-windows-32": "0.14.47",
-				"esbuild-windows-64": "0.14.47",
-				"esbuild-windows-arm64": "0.14.47"
+				"@esbuild/aix-ppc64": "0.25.2",
+				"@esbuild/android-arm": "0.25.2",
+				"@esbuild/android-arm64": "0.25.2",
+				"@esbuild/android-x64": "0.25.2",
+				"@esbuild/darwin-arm64": "0.25.2",
+				"@esbuild/darwin-x64": "0.25.2",
+				"@esbuild/freebsd-arm64": "0.25.2",
+				"@esbuild/freebsd-x64": "0.25.2",
+				"@esbuild/linux-arm": "0.25.2",
+				"@esbuild/linux-arm64": "0.25.2",
+				"@esbuild/linux-ia32": "0.25.2",
+				"@esbuild/linux-loong64": "0.25.2",
+				"@esbuild/linux-mips64el": "0.25.2",
+				"@esbuild/linux-ppc64": "0.25.2",
+				"@esbuild/linux-riscv64": "0.25.2",
+				"@esbuild/linux-s390x": "0.25.2",
+				"@esbuild/linux-x64": "0.25.2",
+				"@esbuild/netbsd-arm64": "0.25.2",
+				"@esbuild/netbsd-x64": "0.25.2",
+				"@esbuild/openbsd-arm64": "0.25.2",
+				"@esbuild/openbsd-x64": "0.25.2",
+				"@esbuild/sunos-x64": "0.25.2",
+				"@esbuild/win32-arm64": "0.25.2",
+				"@esbuild/win32-ia32": "0.25.2",
+				"@esbuild/win32-x64": "0.25.2"
 			}
-		},
-		"esbuild-android-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.47.tgz",
-			"integrity": "sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-android-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.47.tgz",
-			"integrity": "sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-darwin-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.47.tgz",
-			"integrity": "sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-darwin-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.47.tgz",
-			"integrity": "sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-freebsd-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.47.tgz",
-			"integrity": "sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-freebsd-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.47.tgz",
-			"integrity": "sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-32": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.47.tgz",
-			"integrity": "sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.47.tgz",
-			"integrity": "sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-arm": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.47.tgz",
-			"integrity": "sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.47.tgz",
-			"integrity": "sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-mips64le": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.47.tgz",
-			"integrity": "sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-ppc64le": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.47.tgz",
-			"integrity": "sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-riscv64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.47.tgz",
-			"integrity": "sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-s390x": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.47.tgz",
-			"integrity": "sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-netbsd-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.47.tgz",
-			"integrity": "sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-openbsd-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz",
-			"integrity": "sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-sunos-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz",
-			"integrity": "sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-windows-32": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.47.tgz",
-			"integrity": "sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-windows-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.47.tgz",
-			"integrity": "sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-windows-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.47.tgz",
-			"integrity": "sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==",
-			"dev": true,
-			"optional": true
 		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
@@ -5248,9 +5344,9 @@
 			}
 		},
 		"fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"
@@ -5807,6 +5903,8 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"peer": true,
 			"requires": {
 				"argparse": "^2.0.1"
 			}
@@ -5870,15 +5968,6 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"requires": {
-				"yallist": "^4.0.0"
-			}
-		},
 		"math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5892,12 +5981,12 @@
 			"dev": true
 		},
 		"micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
 			"requires": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			}
 		},
@@ -6276,13 +6365,10 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
-			"requires": {
-				"lru-cache": "^6.0.0"
-			}
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"dev": true
 		},
 		"set-function-length": {
 			"version": "1.2.2",
@@ -6704,9 +6790,9 @@
 			}
 		},
 		"word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
 			"peer": true
 		},
@@ -6716,12 +6802,6 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true,
 			"peer": true
-		},
-		"yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
 		},
 		"yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
-		"esbuild": "0.14.47",
+		"esbuild": "^0.25.2",
 		"eslint-plugin-import": "^2.31.0",
 		"eslint-plugin-simple-import-sort": "^12.1.1",
 		"obsidian": "latest",

--- a/src/context/sharedSettingsContext.ts
+++ b/src/context/sharedSettingsContext.ts
@@ -1,0 +1,18 @@
+import { ContactsPluginSettings } from "src/settings/settings";
+
+let _settings: ContactsPluginSettings | undefined
+
+export function setSettings(settings: ContactsPluginSettings) {
+  _settings = settings
+}
+
+export function getSettings(): ContactsPluginSettings {
+  if (!_settings) {
+    throw new Error('Plugin context has not been set.')
+  }
+  return _settings
+}
+
+export function clearSettings() {
+  _settings = undefined;
+}

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -1,4 +1,6 @@
 import {App, normalizePath, Notice, TAbstractFile, TFile, TFolder, Vault, Workspace} from "obsidian";
+import { getSettings } from "src/context/sharedSettingsContext";
+import { ContactsPluginSettings } from "src/settings/settings";
 import { FileExistsModal } from "src/ui/modals/fileExistsModal";
 
 export async function openFile(file: TFile, workspace: Workspace) {
@@ -148,4 +150,10 @@ export function createFileName(records: Record<string, string>) {
 		.map(part => part.trim())
 		.filter(part => part !== '')
 		.join(' ') + '.md';
+}
+
+let settings: ContactsPluginSettings| null = null;
+export function isFileInFolder(file: TAbstractFile) {
+  if (!settings) { settings = getSettings()}
+  return file.path.startsWith(settings.contactsFolder);
 }

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -138,7 +138,6 @@ export function saveVcardFilePicker(data: string, obsidianFile?: TFile ) {
      * This dependency can change at any point but there is no alternative
      * found that can actually share without extra user click on IOS and Android
     **/
-    console.log('starting');
     // @ts-ignore
     if(Platform.isMobileApp && window.Capacitor && typeof window.Capacitor.Plugins.Filesystem.open === 'function') {
       (async () => {

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -1,5 +1,4 @@
 import {App, normalizePath, Notice, TAbstractFile, TFile, TFolder, Vault, Workspace} from "obsidian";
-import { join } from "path";
 import { FileExistsModal } from "src/ui/modals/fileExistsModal";
 
 export async function openFile(file: TFile, workspace: Workspace) {
@@ -61,10 +60,10 @@ export function createContactFile(
 	const parentFolder = activeFile?.parent; // Get the parent folder if it's a file
 
 	if (parentFolder?.path?.contains(folderPath)) {
-		const filePath = normalizePath(join(parentFolder.path, filename));
+		const filePath = normalizePath(fileJoin(parentFolder.path, filename));
 		handleFileCreation(app, filePath, content);
 	} else {
-		const filePath = normalizePath(join(folderPath, filename));
+		const filePath = normalizePath(fileJoin(folderPath, filename));
 		handleFileCreation(app, filePath, content);
 	}
 }
@@ -76,6 +75,14 @@ export function fileId(file: TAbstractFile): string {
 		hash |= 0; // Convert to 32-bit integer
 	}
 	return Math.abs(hash).toString(); // Ensure it's positive
+}
+
+export function fileJoin(...parts: string[]): string {
+  return parts
+    .filter(Boolean)
+    .join("/")
+    .replace(/\/{2,}/g, "/")
+    .replace(/\/+$/, "");
 }
 
 export async function openFilePicker(type: string): Promise<string | Blob> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 import { Plugin } from 'obsidian';
 import { ContactsView } from "src/ui/sidebar/sidebarView";
 import { CONTACTS_VIEW_CONFIG } from "src/util/constants";
+import myScrollTo from "src/util/myScrollTo";
+
 import { ContactsPluginSettings, ContactsSettingTab, DEFAULT_SETTINGS } from './settings/settings';
 
 export default class ContactsPlugin extends Plugin {
@@ -15,6 +17,7 @@ export default class ContactsPlugin extends Plugin {
 
 		this.addRibbonIcon('contact', 'Contacts', () => {
 			this.activateSidebarView();
+      myScrollTo.handleLeafEvent(null);
 		});
 
 		this.addSettingTab(new ContactsSettingTab(this.app, this));

--- a/src/ui/sidebar/components/ContactView.tsx
+++ b/src/ui/sidebar/components/ContactView.tsx
@@ -177,7 +177,10 @@ export const ContactView = (props: ContactProps) => {
 								}
 								aria-label="Process avatar"
 								ref={(element) => (buttons.current[0] = element)}
-								onClick={() => props.processAvatar(contact)}
+								onClick={(event) => {
+                  event.stopPropagation();
+                  props.processAvatar(contact);
+                }}
 							>
 							</div>
 							<div
@@ -187,7 +190,10 @@ export const ContactView = (props: ContactProps) => {
 								}
 								aria-label="Export vcf"
 								ref={(element) => (buttons.current[1] = element)}
-								onClick={() => props.exportVCF(contact.file)}
+								onClick={(event) => {
+                  event.stopPropagation();
+                  props.exportVCF(contact.file);
+                }}
 							>
 							</div>
 						</div>

--- a/src/ui/sidebar/components/ContactsListView.tsx
+++ b/src/ui/sidebar/components/ContactsListView.tsx
@@ -1,7 +1,7 @@
-import { randomUUID } from "crypto";
 import { TFile } from "obsidian";
 import * as React from "react";
 import { Contact } from "src/contacts";
+import { fileId } from "src/file/file";
 import { ContactView } from "src/ui/sidebar/components/ContactView";
 import { Sort } from "src/util/constants";
 import myScrollTo from "src/util/myScrollTo";
@@ -95,7 +95,7 @@ export const ContactsListView = (props: ContactsListProps) => {
 	return (
 		<>
 			{processedContacts.map((contact) => {
-				return <ContactView contact={contact} key={randomUUID()} exportVCF={props.exportVCF} processAvatar={props.processAvatar} />;
+				return <ContactView contact={contact} key={fileId(contact.file)} exportVCF={props.exportVCF} processAvatar={props.processAvatar} />;
 			})}
 		</>
 	);

--- a/src/ui/sidebar/components/HeaderView.tsx
+++ b/src/ui/sidebar/components/HeaderView.tsx
@@ -1,15 +1,17 @@
 import { setIcon } from "obsidian";
+import { Dispatch, SetStateAction } from "react";
 import * as React from "react";
 import { Sort } from "src/util/constants";
 
 
 type HeaderProps = {
-	onSortChange: React.Dispatch<React.SetStateAction<Sort>>;
-	sort: Sort;
-	onCreateContact: () => void;
-	importVCF: () => void;
-	exportAllVCF: () => void;
-};
+  onSortChange: React.Dispatch<React.SetStateAction<Sort>>;
+  sort: Sort;
+  onCreateContact: () => void;
+  importVCF: () => void;
+  exportAllVCF: () => void;
+  setDisplayInsightsView: Dispatch<SetStateAction<boolean>>;
+}
 
 export const HeaderView = (props: HeaderProps) => {
 	const buttons = React.useRef<(HTMLElement | null)[]>([]);
@@ -19,76 +21,67 @@ export const HeaderView = (props: HeaderProps) => {
 	}, [buttons]);
 
 	return (
-		<div className="contacts-menu">
-			<div className="nav-header">
-				<div className="nav-buttons-container">
-					<div
-						id="create-btn"
-						className="clickable-icon nav-action-button"
-						data-icon="contact"
-						aria-label="Create new contact"
-						ref={(element) => (buttons.current[1] = element)}
-						onClick={props.onCreateContact}
-					/>
+    <div className="nav-buttons-container">
+      <div
+        id="create-btn"
+        className="clickable-icon nav-action-button"
+        data-icon="contact"
+        aria-label="Create new contact"
+        ref={(element) => (buttons.current[1] = element)}
+        onClick={props.onCreateContact}/>
 
-					<div
-						id="import-vcf-btn"
-						data-icon="file-down"
-						className={
-							"clickable-icon nav-action-button "
-						}
-						aria-label="Import vcf"
-						ref={(element) => (buttons.current[2] = element)}
-						onClick={ props.importVCF }
-					/>
-					<div
-						id="import-vcf-btn"
-						data-icon="file-up"
-						className={
-							"clickable-icon nav-action-button "
-						}
-						aria-label="Export vcf"
-						ref={(element) => (buttons.current[3] = element)}
-						onClick={ props.exportAllVCF }
-					/>
+      <div
+        id="import-vcf-btn"
+        data-icon="file-down"
+        className={"clickable-icon nav-action-button "}
+        aria-label="Import vcf"
+        ref={(element) => (buttons.current[2] = element)}
+        onClick={props.importVCF}/>
+      <div
+        id="import-vcf-btn"
+        data-icon="file-up"
+        className={"clickable-icon nav-action-button "}
+        aria-label="Export vcf"
+        ref={(element) => (buttons.current[3] = element)}
+        onClick={props.exportAllVCF}/>
 
-					<div className="menu-vert"></div>
-					<div
-						id="sort-by-name-btn"
-						data-icon="baseline"
-						className={
-							"clickable-icon nav-action-button " +
-							(props.sort === Sort.NAME && "is-active")
-						}
-						aria-label="Sort by name"
-						ref={(element) => (buttons.current[4] = element)}
-						onClick={() => props.onSortChange(Sort.NAME)}
-					/>
-					<div
-						id="sort-by-birthday-btn"
-						data-icon="cake"
-						className={
-							"clickable-icon nav-action-button " +
-							(props.sort === Sort.BIRTHDAY && "is-active")
-						}
-						aria-label="Sort by birthday"
-						ref={(element) => (buttons.current[6] = element)}
-						onClick={() => props.onSortChange(Sort.BIRTHDAY)}
-					/>
-					<div
-						id="sort-by-organization-btn"
-						data-icon="building"
-						className={
-							"clickable-icon nav-action-button " +
-							(props.sort === Sort.ORG && "is-active")
-						}
-						aria-label="Sort by organization"
-						ref={(element) => (buttons.current[7] = element)}
-						onClick={() => props.onSortChange(Sort.ORG)}
-					/>
-				</div>
-			</div>
-		</div>
+      <div className="menu-vert"></div>
+      <div
+        id="sort-by-name-btn"
+        data-icon="baseline"
+        className={"clickable-icon nav-action-button " +
+          (props.sort === Sort.NAME && "is-active")}
+        aria-label="Sort by name"
+        ref={(element) => (buttons.current[4] = element)}
+        onClick={() => props.onSortChange(Sort.NAME)}/>
+      <div
+        id="sort-by-birthday-btn"
+        data-icon="cake"
+        className={"clickable-icon nav-action-button " +
+          (props.sort === Sort.BIRTHDAY && "is-active")}
+        aria-label="Sort by birthday"
+        ref={(element) => (buttons.current[6] = element)}
+        onClick={() => props.onSortChange(Sort.BIRTHDAY)}/>
+      <div
+        id="sort-by-organization-btn"
+        data-icon="building"
+        className={"clickable-icon nav-action-button " +
+          (props.sort === Sort.ORG && "is-active")}
+        aria-label="Sort by organization"
+        ref={(element) => (buttons.current[7] = element)}
+        onClick={() => props.onSortChange(Sort.ORG)}/>
+
+      <div className="menu-vert"></div>
+
+      <div
+        id="insights-btn"
+        data-icon="lightbulb"
+        className="clickable-icon nav-action-button"
+        aria-label="Contact insights"
+        ref={(element) => (buttons.current[8] = element)}
+        onClick={() => props.setDisplayInsightsView(true)}/>
+
+    </div>
 	);
 };
 

--- a/src/ui/sidebar/components/InsightsView.tsx
+++ b/src/ui/sidebar/components/InsightsView.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+type ActionProps = {
+  setDisplayInsightsView: (displayActionView: boolean) => void;
+};
+
+export const InsightsView = (props: ActionProps) => {
+
+  return (
+    <div className="contacts-view">
+      <button onClick={ () => props.setDisplayInsightsView(false)}>back</button>
+
+      <div className="action-card">
+        <div className="action-card-content action-card-content--no-height">
+          <p><b>Roland Broekema</b> birthdays is today.</p>
+        </div>
+        <div className="modal-close-button"></div>
+      </div>
+      <div className="action-card">
+        <div className="action-card-content">
+          <p><b>3</b> birthdays in the next 7 days.</p>
+          <p><b>16</b> profile improvements possible.</p>
+        </div>
+        <button
+          className="action-card-button"
+        >Go</button>
+        <div className="modal-close-button"></div>
+      </div>
+    </div>
+  )
+}

--- a/src/ui/sidebar/components/InsightsView.tsx
+++ b/src/ui/sidebar/components/InsightsView.tsx
@@ -12,20 +12,20 @@ export const InsightsView = (props: ActionProps) => {
 
       <div className="action-card">
         <div className="action-card-content action-card-content--no-height">
-          <p><b>Roland Broekema</b> birthdays is today.</p>
+          <p>No insights available yet.</p>
         </div>
-        <div className="modal-close-button"></div>
+        {/*<div className="modal-close-button"></div>*/}
       </div>
-      <div className="action-card">
-        <div className="action-card-content">
-          <p><b>3</b> birthdays in the next 7 days.</p>
-          <p><b>16</b> profile improvements possible.</p>
-        </div>
-        <button
-          className="action-card-button"
-        >Go</button>
-        <div className="modal-close-button"></div>
-      </div>
+      {/*<div className="action-card">*/}
+      {/*  <div className="action-card-content">*/}
+      {/*    <p><b>3</b> birthdays in the next 7 days.</p>*/}
+      {/*    <p><b>16</b> profile improvements possible.</p>*/}
+      {/*  </div>*/}
+      {/*  <button*/}
+      {/*    className="action-card-button"*/}
+      {/*  >Go</button>*/}
+      {/*  <div className="modal-close-button"></div>*/}
+      {/*</div>*/}
     </div>
   )
 }

--- a/src/ui/sidebar/components/SidebarRootView.tsx
+++ b/src/ui/sidebar/components/SidebarRootView.tsx
@@ -3,38 +3,32 @@ import * as React from "react";
 import { Contact, getFrontmatterFromFiles, mdRender } from "src/contacts";
 import { createEmptyVcard, parseToSingles, parseVcard, vcardToString } from "src/contacts/vcard";
 import { getApp } from "src/context/sharedAppContext";
+import { getSettings } from "src/context/sharedSettingsContext";
 import {
   createContactFile,
   createFileName,
-  findContactFiles,
+  findContactFiles, isFileInFolder,
   openFilePicker,
   saveVcardFilePicker
 } from "src/file/file";
-import ContactsPlugin from "src/main";
 import { ContactsListView } from "src/ui/sidebar/components/ContactsListView";
 import { HeaderView } from "src/ui/sidebar/components/HeaderView";
+import { InsightsView } from "src/ui/sidebar/components/InsightsView";
 import { processAvatar } from "src/util/avatarActions";
 import { Sort } from "src/util/constants";
 import myScrollTo from "src/util/myScrollTo";
 
+export const SidebarRootView = () => {
+	const { vault, workspace } = getApp();
 
-type RootProps = {
-	plugin: ContactsPlugin;
-};
-
-export const SidebarRootView = (props: RootProps) => {
-	const { vault } = getApp();
 	const [contacts, setContacts] = React.useState<Contact[]>([]);
+  const [displayInsightsView, setDisplayInsightsView] = React.useState<boolean>(false);
 	const [sort, setSort] = React.useState<Sort>(Sort.NAME);
-	const folder = props.plugin.settings.contactsFolder;
-
-	const isFileInFolder = (file: TAbstractFile) => {
-		return file.path.startsWith(folder);
-	};
+	const settings = getSettings();
 
 	const parseContacts = () => {
 		const contactsFolder = vault.getAbstractFileByPath(
-			normalizePath(folder)
+			normalizePath(settings.contactsFolder)
 		)
 
 		if (!(contactsFolder instanceof TFolder)) {
@@ -72,68 +66,89 @@ export const SidebarRootView = (props: RootProps) => {
 			vault.off("rename", updateFiles);
 			vault.off("delete", updateFiles);
 		};
-	}, [vault, folder]);
+	}, [vault, settings.contactsFolder]);
 
-	React.useEffect(() => {
-		app.workspace.on("active-leaf-change", (leaf: WorkspaceLeaf):void => {
-			myScrollTo.scrollToLeaf(leaf);
-		});
 
-		return () => {
-			myScrollTo.clearDebounceTimer()
-			app.workspace.off("active-leaf-change", myScrollTo.scrollToLeaf);
-		};
-	}, [app.workspace]);
+  React.useEffect(() => {
+    const handler = (leaf: WorkspaceLeaf): void => {
+      myScrollTo.handleLeafEvent(leaf);
+    };
+
+    workspace.on("active-leaf-change",  myScrollTo.handleLeafEvent);
+
+    return () => {
+      myScrollTo.clearDebounceTimer();
+      workspace.off("active-leaf-change",  myScrollTo.handleLeafEvent);
+    };
+  }, [workspace]);
 
 	return (
-		<div>
-			<HeaderView
-				onSortChange={setSort}
-				importVCF={() => {
-					openFilePicker('.vcf').then(async (fileContent: string) => {
-						if (fileContent === '') {
-							return;
-						} else {
-							const singles: string[] = parseToSingles(fileContent);
-							for (const single of singles) {
-								const records = await parseVcard(single);
-								const mdContent = mdRender(records, props.plugin.settings.defaultHashtag);
-								createContactFile(app, folder, mdContent, createFileName(records))
-							}
-						}
-					})
-				}}
-				exportAllVCF={async() => {
-					const allContactFiles = contacts.map((contact)=> contact.file)
-					const vcards = await vcardToString(allContactFiles);
-					saveVcardFilePicker(vcards)
-				}}
-				onCreateContact={async () => {
-					const records = await createEmptyVcard();
-					const mdContent = mdRender(records, props.plugin.settings.defaultHashtag);
-					createContactFile(app, folder, mdContent, createFileName(records))
-				}}
-				sort={sort}
-			/>
-			<ContactsListView
-				contacts={contacts}
-				sort={sort}
-				processAvatar={(contact :Contact) => {
-					(async () => {
-						try {
-							await processAvatar(contact);
-							setTimeout(() => { parseContacts() }, 50);
-						} catch (err) {
-							new Notice(err.message);
-						}
-					})();
-				}}
-				exportVCF={(contactFile: TFile) => {
-					(async () => {
-						const vcards = await vcardToString([contactFile])
-						saveVcardFilePicker(vcards, contactFile)
-					})();
-				}} />
-		</div>
+		<div className="contacts-sidebar">
+      { displayInsightsView ?
+        <InsightsView
+          setDisplayInsightsView={setDisplayInsightsView}
+        />
+      :
+        <>
+        <div className="contacts-menu">
+          <div className="nav-header">
+              <HeaderView
+                onSortChange={setSort}
+                importVCF={() => {
+                  openFilePicker('.vcf').then(async (fileContent: string) => {
+                    if (fileContent === '') {
+                      return;
+                    } else {
+                      const singles: string[] = parseToSingles(fileContent);
+                      for (const single of singles) {
+                        const records = await parseVcard(single);
+                        const mdContent = mdRender(records, settings.defaultHashtag);
+                        createContactFile(app, settings.contactsFolder, mdContent, createFileName(records))
+                      }
+                    }
+                  })
+                }}
+                exportAllVCF={async() => {
+                  const allContactFiles = contacts.map((contact)=> contact.file)
+                  const vcards = await vcardToString(allContactFiles);
+                  saveVcardFilePicker(vcards)
+                }}
+                onCreateContact={async () => {
+                  const records = await createEmptyVcard();
+                  const mdContent = mdRender(records, settings.defaultHashtag);
+                  createContactFile(app, settings.contactsFolder, mdContent, createFileName(records))
+                }}
+                setDisplayInsightsView={setDisplayInsightsView}
+                sort={sort}
+              />
+            <div className="nav-actionable-container">
+
+            </div>
+          </div>
+        </div>
+        <div className="contacts-view">
+          <ContactsListView
+            contacts={contacts}
+            sort={sort}
+            processAvatar={(contact :Contact) => {
+              (async () => {
+                try {
+                  await processAvatar(contact);
+                  setTimeout(() => { parseContacts() }, 50);
+                } catch (err) {
+                  new Notice(err.message);
+                }
+              })();
+            }}
+            exportVCF={(contactFile: TFile) => {
+              (async () => {
+                const vcards = await vcardToString([contactFile])
+                saveVcardFilePicker(vcards, contactFile)
+              })();
+            }} />
+        </div>
+      </>
+    }
+  </div>
 	);
 };

--- a/src/ui/sidebar/components/SidebarRootView.tsx
+++ b/src/ui/sidebar/components/SidebarRootView.tsx
@@ -1,4 +1,4 @@
-import { normalizePath, Notice, TAbstractFile, TFile, TFolder, WorkspaceLeaf } from "obsidian";
+import { MarkdownView, normalizePath, Notice, TAbstractFile, TFile, TFolder } from "obsidian";
 import * as React from "react";
 import { Contact, getFrontmatterFromFiles, mdRender } from "src/contacts";
 import { createEmptyVcard, parseToSingles, parseVcard, vcardToString } from "src/contacts/vcard";
@@ -70,9 +70,9 @@ export const SidebarRootView = () => {
 
 
   React.useEffect(() => {
-    const handler = (leaf: WorkspaceLeaf): void => {
-      myScrollTo.handleLeafEvent(leaf);
-    };
+
+    const view = app.workspace.getActiveViewOfType(MarkdownView);
+    myScrollTo.handleOpenWhenNoLeafEventYet(view?.leaf);
 
     workspace.on("active-leaf-change",  myScrollTo.handleLeafEvent);
 

--- a/src/ui/sidebar/sidebarView.tsx
+++ b/src/ui/sidebar/sidebarView.tsx
@@ -2,6 +2,7 @@ import { ItemView, WorkspaceLeaf } from "obsidian";
 import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { clearApp, setApp } from "src/context/sharedAppContext";
+import { clearSettings, setSettings } from "src/context/sharedSettingsContext";
 import ContactsPlugin from "src/main";
 import { SidebarRootView } from "src/ui/sidebar/components/SidebarRootView";
 import { CONTACTS_VIEW_CONFIG } from "src/util/constants";
@@ -28,13 +29,15 @@ export class ContactsView extends ItemView {
 
 	async onOpen(){
 		setApp(this.app);
+    setSettings(this.plugin.settings);
 		this.root.render(
-				<SidebarRootView plugin={this.plugin} />
+				<SidebarRootView />
 		);
 	}
 
 	async onClose() {
 		clearApp();
+    clearSettings();
 		this.root.unmount();
 	}
 }

--- a/src/util/myScrollTo.ts
+++ b/src/util/myScrollTo.ts
@@ -4,7 +4,15 @@ import { fileId, isFileInFolder } from "src/file/file";
 let debounceTimer: number
 let lastContactLeaf: WorkspaceLeaf | null = null;
 
+const handleOpenWhenNoLeafEventYet =  (leaf: WorkspaceLeaf | undefined):void => {
+  console.log('brppp', leaf);
+  if (leaf?.view instanceof MarkdownView && lastContactLeaf === null) {
+    handleLeafEvent(leaf);
+  }
+}
+
 const handleLeafEvent = (leaf: WorkspaceLeaf | null):void => {
+  console.log('handler', leaf);
   const viewType = leaf?.view?.getViewType?.();
 
   if (leaf?.view instanceof MarkdownView) {
@@ -44,7 +52,7 @@ const scrollToLeaf = (leaf: WorkspaceLeaf):void => {
 				behavior: "smooth",
 			});
 		});
-	}, 50);
+	}, 550);
 };
 
 const scrollToTop = ():void => {
@@ -66,5 +74,6 @@ const clearDebounceTimer = ():void => {
 export default {
 	scrollToTop,
   handleLeafEvent,
+  handleOpenWhenNoLeafEventYet,
 	clearDebounceTimer,
 }

--- a/src/util/myScrollTo.ts
+++ b/src/util/myScrollTo.ts
@@ -1,7 +1,23 @@
 import { MarkdownView, WorkspaceLeaf } from "obsidian";
-import { fileId } from "src/file/file";
+import { fileId, isFileInFolder } from "src/file/file";
 
 let debounceTimer: number
+let lastContactLeaf: WorkspaceLeaf | null = null;
+
+const handleLeafEvent = (leaf: WorkspaceLeaf | null):void => {
+  const viewType = leaf?.view?.getViewType?.();
+
+  if (leaf?.view instanceof MarkdownView) {
+    if (isFileInFolder(leaf?.view?.file)) {
+      lastContactLeaf = leaf;
+      scrollToLeaf(lastContactLeaf);
+    }
+  } else if (viewType === 'contacts-view' && lastContactLeaf !== null) {
+    scrollToLeaf(lastContactLeaf);
+  } else if (leaf === null && lastContactLeaf !== null) {
+    scrollToLeaf(lastContactLeaf);
+  }
+}
 
 const scrollToLeaf = (leaf: WorkspaceLeaf):void => {
 	clearTimeout(debounceTimer); // Reset debounce timer
@@ -12,7 +28,7 @@ const scrollToLeaf = (leaf: WorkspaceLeaf):void => {
 		if (!contactElement) return;
 
 
-		const scrollContainer = contactElement.closest(".view-content") as HTMLElement | null;
+		const scrollContainer = document.querySelector(".contacts-view") as HTMLElement | null;
 		if (!scrollContainer) return;
 
 		const elementRect = contactElement.getBoundingClientRect();
@@ -32,7 +48,7 @@ const scrollToLeaf = (leaf: WorkspaceLeaf):void => {
 };
 
 const scrollToTop = ():void => {
-		const scrollContainer = document.querySelector('.contacts-menu')?.closest(".view-content") as HTMLElement | null;
+		const scrollContainer = document.querySelector(".contacts-view") as HTMLElement | null;
 		if (!scrollContainer) return;
 		requestAnimationFrame(() => {
 			scrollContainer.scrollTo({
@@ -49,6 +65,6 @@ const clearDebounceTimer = ():void => {
 
 export default {
 	scrollToTop,
-	scrollToLeaf,
+  handleLeafEvent,
 	clearDebounceTimer,
 }

--- a/src/util/myScrollTo.ts
+++ b/src/util/myScrollTo.ts
@@ -52,7 +52,7 @@ const scrollToLeaf = (leaf: WorkspaceLeaf):void => {
 				behavior: "smooth",
 			});
 		});
-	}, 550);
+	}, 50);
 };
 
 const scrollToTop = ():void => {

--- a/styles.css
+++ b/styles.css
@@ -4,9 +4,19 @@
 	margin-right: 2px;
 }
 
+.contacts-sidebar {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
 
 .contacts-menu {
-	margin-top: 35px;
+  padding-right: 12px; // scrollbarSpacing
+}
+
+.contacts-view {
+  overflow-y: auto;
+  scrollbar-gutter: stable;
 }
 
 .contact-card {
@@ -33,17 +43,6 @@
 	width: 100%;
 }
 
-
-.contacts-menu .nav-header {
-	position: absolute;
-	background-color: var(--titlebar-background);
-	position: fixed;
-	left: 0;
-	top: 0;
-	right: 0;
-	z-index: 99;
-}
-
 .inner-card-container {
 	container-name: bizzy-card;
 	container-type: inline-size;
@@ -60,7 +59,7 @@
 	max-width: 450px;
 	flex-basis: auto;
 	flex-wrap: wrap;
-	border-radius: 18px;
+	border-radius: 12px;
 	overflow: hidden;
 
 }
@@ -187,7 +186,7 @@
 	left: 40px;
 	height: 308px;
 	border-radius: 50px;
-	width: 120%;
+	width: 300px;
 	color: var(--tag-color);
 	border: 2px solid var(--tag-border-color);
 	z-index: -1;
@@ -221,10 +220,71 @@
 	text-decoration: none;
 }
 
+.action-card {
+  position: relative;
+  width: 100%;
+  padding: 8px;
+  border-radius: 12px;
+  border: 2px solid var(--divider-color);
+  margin: 8px 0;
+  display: flex;
+  align-items: center;
+}
+
+.action-card-content {
+  min-height: 55px;
+  flex: 1 1 auto;
+  color: var(--metadata-label-text-color);
+}
+
+.action-card-content.action-card-content--no-height {
+  min-height: 0;
+}
+
+.action-card-content p {
+  margin: 8px;
+}
+
+.action-card-button {
+  align-self: end;
+}
+
+.action-card:last-child {
+  margin-bottom: 0;
+}
+
+.view-content:has(.contacts-sidebar) {
+  padding-right: 0;
+}
+
+.nav-actionable-container {
+  container-name: actionable-card;
+  container-type: inline-size;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+@Container actionable-card (max-width: 410px) {
+  .action-card {
+    max-width: 240px;
+    flex-direction: column;
+    align-items: normal;
+  }
+
+  .action-card-content {
+    padding-bottom: 8px;
+  }
+
+  .action-card-button {
+    align-self: normal;
+  }
+}
+
 /*=============================
 	 Business Card Mobile
 ===============================*/
-@Container bizzy-card (max-width: 430px) {
+@Container bizzy-card (max-width: 410px) {
 	.bizzy-card-container {
 		width: 240px;
 	}
@@ -262,7 +322,7 @@
 	.biz-shape {
 		transform: scaleX(1) rotate(85deg);
 		top: 0;
-		left: 35px;
+		left: 0;
 	}
 
 	.biz-contact-box {
@@ -272,3 +332,7 @@
 		width: 100%;
 	}
 }
+
+
+
+


### PR DESCRIPTION
Key Changes:

    1) Layout adjustments for mobile screens and Insights view.
    2) Removed Node.js only dependencies; replaced with mobile-compatible equivalents.
    3) VCF export now writes to /Documents/ on mobile devices, 

Notes:
   1) Exported contact files can now be accessed via the system Files app for sharing. Since capacitor.open with vcf, window.open, navigator.share, and blob-based download links are not working, supported within Obsidian’s mobile WebView.
   