### PR TITLE
Fix #7: Improve Contacts Folder Setting with Selector and Reactive Updating UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"esbuild": "^0.25.2",
 				"eslint-plugin-import": "^2.31.0",
 				"eslint-plugin-simple-import-sort": "^12.1.1",
-				"obsidian": "latest",
+				"obsidian": "^1.8.7",
 				"tslib": "2.4.0",
 				"typescript": "4.7.4"
 			}
@@ -548,18 +548,18 @@
 			"dev": true
 		},
 		"node_modules/@types/codemirror": {
-			"version": "0.0.108",
-			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.108.tgz",
-			"integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
+			"version": "5.60.8",
+			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+			"integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
 			"dev": true,
 			"dependencies": {
 				"@types/tern": "*"
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+			"integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
 			"dev": true
 		},
 		"node_modules/@types/json-schema": {
@@ -613,9 +613,9 @@
 			"dev": true
 		},
 		"node_modules/@types/tern": {
-			"version": "0.23.4",
-			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
-			"integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
+			"version": "0.23.9",
+			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+			"integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "*"
@@ -3002,12 +3002,12 @@
 			}
 		},
 		"node_modules/obsidian": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.16.3.tgz",
-			"integrity": "sha512-hal9qk1A0GMhHSeLr2/+o3OpLmImiP+Y+sx2ewP13ds76KXsziG96n+IPFT0mSkup1zSwhEu+DeRhmbcyCCXWw==",
+			"version": "1.8.7",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.8.7.tgz",
+			"integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
 			"dev": true,
 			"dependencies": {
-				"@types/codemirror": "0.0.108",
+				"@types/codemirror": "5.60.8",
 				"moment": "2.29.4"
 			},
 			"peerDependencies": {
@@ -4322,18 +4322,18 @@
 			"dev": true
 		},
 		"@types/codemirror": {
-			"version": "0.0.108",
-			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.108.tgz",
-			"integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
+			"version": "5.60.8",
+			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+			"integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
 			"dev": true,
 			"requires": {
 				"@types/tern": "*"
 			}
 		},
 		"@types/estree": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+			"integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
 			"dev": true
 		},
 		"@types/json-schema": {
@@ -4387,9 +4387,9 @@
 			"dev": true
 		},
 		"@types/tern": {
-			"version": "0.23.4",
-			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
-			"integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
+			"version": "0.23.9",
+			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+			"integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "*"
@@ -6086,12 +6086,12 @@
 			}
 		},
 		"obsidian": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.16.3.tgz",
-			"integrity": "sha512-hal9qk1A0GMhHSeLr2/+o3OpLmImiP+Y+sx2ewP13ds76KXsziG96n+IPFT0mSkup1zSwhEu+DeRhmbcyCCXWw==",
+			"version": "1.8.7",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.8.7.tgz",
+			"integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
 			"dev": true,
 			"requires": {
-				"@types/codemirror": "0.0.108",
+				"@types/codemirror": "5.60.8",
 				"moment": "2.29.4"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"esbuild": "^0.25.2",
 		"eslint-plugin-import": "^2.31.0",
 		"eslint-plugin-simple-import-sort": "^12.1.1",
-		"obsidian": "latest",
+		"obsidian": "^1.8.7",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"
 	},

--- a/src/contacts/vcard/vcardParse.ts
+++ b/src/contacts/vcard/vcardParse.ts
@@ -1,4 +1,5 @@
 import { VCardForObsidianRecord, VCardStructuredFields, VCardSupportedKey } from "src/contacts/vcard";
+import { getApp } from "src/context/sharedAppContext";
 import { ContactNameModal } from "src/ui/modals/contactNameModal";
 import { convertToLatestVCFPhotoFormat } from "src/util/avatarActions";
 
@@ -264,7 +265,8 @@ export async function parseVcard(vCardData: string) {
 }
 
 export async function checkOrAskForName(vCardObject: VCardForObsidianRecord): Promise<VCardForObsidianRecord> {
-	return new Promise((resolve) => {
+	const app = getApp();
+  return new Promise((resolve) => {
 		if (vCardObject['N.GN'] && vCardObject['N.FN']) {
 			resolve(vCardObject);
 		} else {

--- a/src/context/sharedSettingsContext.ts
+++ b/src/context/sharedSettingsContext.ts
@@ -1,9 +1,12 @@
 import { ContactsPluginSettings } from "src/settings/settings";
+type SettingsListener = (settings: ContactsPluginSettings) => void;
 
 let _settings: ContactsPluginSettings | undefined
+const _listeners = new Set<SettingsListener>();
 
 export function setSettings(settings: ContactsPluginSettings) {
   _settings = settings
+  _listeners.forEach((listener) => listener(settings));
 }
 
 export function getSettings(): ContactsPluginSettings {
@@ -15,4 +18,10 @@ export function getSettings(): ContactsPluginSettings {
 
 export function clearSettings() {
   _settings = undefined;
+  _listeners.clear();
+}
+
+export function onSettingsChange(listener: SettingsListener) {
+  _listeners.add(listener);
+  return () => _listeners.delete(listener);
 }

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -31,7 +31,7 @@ async function handleFileCreation(app: App, filePath: string, content: string) {
 	const fileExists = await app.vault.adapter.exists(filePath);
 
 	if (fileExists) {
-		new FileExistsModal(filePath, async (action: "replace" | "skip") => {
+		new FileExistsModal(app, filePath, async (action: "replace" | "skip") => {
 			if (action === "skip") {
 				new Notice("File creation skipped.");
 				return;
@@ -58,7 +58,7 @@ export function createContactFile(
 	content: string,
 	filename: string
 ) {
-	const folder = app.vault.getAbstractFileByPath(folderPath);
+	const folder = app.vault.getAbstractFileByPath(folderPath !== '' ? folderPath : '/') ;
 	if (!folder) {
 		new Notice(`Can not find path: '${folderPath}'. Please update "Contacts" plugin settings`);
 		return;
@@ -75,7 +75,7 @@ export function createContactFile(
 	}
 }
 
-export function fileId(file: TAbstractFile): string {
+export function fileId(file: TFile): string {
 	let hash = 0;
 	for (let i = 0; i < file.path.length; i++) {
 		hash = (hash << 5) - hash + file.path.charCodeAt(i);
@@ -195,7 +195,7 @@ export function createFileName(records: Record<string, string>) {
 }
 
 
-export function isFileInFolder(file: TAbstractFile) {
+export function isFileInFolder(file: TFile) {
   const settings = getSettings()
   return file.path.startsWith(settings.contactsFolder);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,13 +38,16 @@ export default class ContactsPlugin extends Plugin {
 
 	async activateSidebarView() {
 		if (this.app.workspace.getLeavesOfType(CONTACTS_VIEW_CONFIG.type).length < 1) {
-			await this.app.workspace.getRightLeaf(false).setViewState({
-				type: CONTACTS_VIEW_CONFIG.type,
-				active: true,
-			});
+      const leaf = this.app.workspace.getRightLeaf(false);
+      if (leaf) {
+        await leaf.setViewState({
+          type: CONTACTS_VIEW_CONFIG.type,
+          active: true,
+        });
+      }
 		}
 
-		this.app.workspace.revealLeaf(
+		await this.app.workspace.revealLeaf(
 			this.app.workspace.getLeavesOfType(CONTACTS_VIEW_CONFIG.type)[0]
 		);
 	}

--- a/src/settings/FolderSuggest.ts
+++ b/src/settings/FolderSuggest.ts
@@ -1,0 +1,44 @@
+import { AbstractInputSuggest, App, TFolder } from 'obsidian';
+import { KeyboardEvent, MouseEvent } from "react";
+import { setSettings } from "src/context/sharedSettingsContext";
+import ContactsPlugin from "src/main";
+
+export class FolderSuggest extends AbstractInputSuggest<string> {
+  folders: string[];
+  private inputEl: HTMLInputElement;
+  private plugin: ContactsPlugin;
+
+  constructor(app: App, plugin: ContactsPlugin, inputEl: HTMLInputElement) {
+    super(app, inputEl);
+    this.inputEl = inputEl;
+    this.plugin = plugin;
+    this.folders = this.getAllFolderPaths().filter(folder => folder.toLowerCase() !== '/');
+  }
+
+  getAllFolderPaths(): string[] {
+    const folders = this.app.vault.getAllLoadedFiles().filter(f => f instanceof TFolder) as TFolder[];
+    return folders.map(f => f.path);
+  }
+
+  getSuggestions(inputStr: string): string[] {
+    return this.folders.filter(folder => folder.toLowerCase().includes(inputStr.toLowerCase()));
+  }
+
+  renderSuggestion(folder: string, el: HTMLElement): void {
+    el.setText(folder);
+  }
+
+  selectSuggestion(folder: string): void {
+    this.inputEl.value = folder;
+    this.inputEl.trigger('input');
+    // Trim folder and Strip ending slash if there
+    let value = folder.trim()
+    value = value.replace(/\/$/, "");
+    this.plugin.settings.contactsFolder = value;
+    this.plugin.saveSettings().then(() => {
+      setSettings(this.plugin.settings);
+      this.close();
+    });
+  }
+
+}

--- a/src/settings/FolderSuggest.ts
+++ b/src/settings/FolderSuggest.ts
@@ -1,5 +1,4 @@
 import { AbstractInputSuggest, App, TFolder } from 'obsidian';
-import { KeyboardEvent, MouseEvent } from "react";
 import { setSettings } from "src/context/sharedSettingsContext";
 import ContactsPlugin from "src/main";
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -3,6 +3,7 @@ import { setSettings } from "src/context/sharedSettingsContext";
 import { InsighSettingProperties } from "src/insights/insightDefinitions";
 import { insightService } from "src/insights/insightService";
 import ContactsPlugin from "src/main";
+import { FolderSuggest } from "src/settings/FolderSuggest";
 
 export interface ContactsPluginSettings {
   contactsFolder: string;
@@ -35,17 +36,21 @@ export class ContactsSettingTab extends PluginSettingTab {
     containerEl.empty();
 
     const contactsFolder = this.plugin.settings.contactsFolder;
-    new Setting(containerEl)
-      .setName('Contacts folder location')
-      .setDesc('Files in this folder and all subfolders will be available as contacts')
-      .addText(text => text
-        .setPlaceholder('Contacts')
-        .setValue(contactsFolder)
-        .onChange(async (value) => {
-          this.plugin.settings.contactsFolder = value;
-          await this.plugin.saveSettings();
-          setSettings(this.plugin.settings);
-        }));
+    new Setting(this.containerEl)
+      .setName("Template folder location")
+      .setDesc("Files in this folder will be available as templates.")
+      .addSearch((cb) => {
+        new FolderSuggest(this.app, this.plugin, cb.inputEl);
+        cb.setPlaceholder("Example: Contacts")
+          .setValue(contactsFolder)
+          .onChange(async(value) => {
+            if(value === '') {
+              this.plugin.settings.contactsFolder = '';
+              await this.plugin.saveSettings();
+              setSettings(this.plugin.settings);
+            }
+          });
+      });
 
     const defaultHashtag = this.plugin.settings.defaultHashtag;
     new Setting(containerEl)

--- a/src/ui/modals/fileExistsModal.tsx
+++ b/src/ui/modals/fileExistsModal.tsx
@@ -1,4 +1,4 @@
-import { Modal } from "obsidian";
+import { App, Modal } from "obsidian";
 import * as React from "react";
 import { createRoot, Root } from "react-dom/client"
 
@@ -40,7 +40,7 @@ export class FileExistsModal extends Modal {
 	callback?: (action: "replace" | "skip") => void;
 	private reactRoot: Root | null = null;
 
-	constructor(filePath:string, callback?: (action: "replace" | "skip") => void) {
+	constructor(app: App, filePath:string, callback?: (action: "replace" | "skip") => void) {
 		super(app);
 		this.filePath = filePath;
 		this.callback = callback;

--- a/src/ui/sidebar/components/SidebarRootView.tsx
+++ b/src/ui/sidebar/components/SidebarRootView.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Contact, getFrontmatterFromFiles, mdRender } from "src/contacts";
 import { createEmptyVcard, parseToSingles, parseVcard, vcardToString } from "src/contacts/vcard";
 import { getApp } from "src/context/sharedAppContext";
-import { getSettings } from "src/context/sharedSettingsContext";
+import { getSettings, onSettingsChange } from "src/context/sharedSettingsContext";
 import {
   createContactFile,
   createFileName,
@@ -19,9 +19,10 @@ import { Sort } from "src/util/constants";
 import myScrollTo from "src/util/myScrollTo";
 
 export const SidebarRootView = () => {
-	const { vault, workspace } = getApp();
+	const app = getApp();
+  const { vault, workspace } = app;
 
-	const [contacts, setContacts] = React.useState<Contact[]>([]);
+  const [contacts, setContacts] = React.useState<Contact[]>([]);
   const [displayInsightsView, setDisplayInsightsView] = React.useState<boolean>(false);
 	const [sort, setSort] = React.useState<Sort>(Sort.NAME);
 	const settings = getSettings();
@@ -43,11 +44,15 @@ export const SidebarRootView = () => {
 
 	React.useEffect(() => {
 		parseContacts();
+    const offSettings = onSettingsChange(parseContacts.bind(this));
+
+    return () => {
+      offSettings();
+    };
 	}, []);
 
 	React.useEffect(() => {
-
-		const updateFiles = (file: TAbstractFile) => {
+		const updateFiles = (file: TFile) => {
 			setTimeout(() => {
 				if (isFileInFolder(file)) {
 					parseContacts();
@@ -71,7 +76,7 @@ export const SidebarRootView = () => {
 
   React.useEffect(() => {
 
-    const view = app.workspace.getActiveViewOfType(MarkdownView);
+    const view = workspace.getActiveViewOfType(MarkdownView);
     myScrollTo.handleOpenWhenNoLeafEventYet(view?.leaf);
 
     workspace.on("active-leaf-change",  myScrollTo.handleLeafEvent);

--- a/src/util/myScrollTo.ts
+++ b/src/util/myScrollTo.ts
@@ -14,7 +14,7 @@ const handleLeafEvent = (leaf: WorkspaceLeaf | null):void => {
   const viewType = leaf?.view?.getViewType?.();
 
   if (leaf?.view instanceof MarkdownView) {
-    if (isFileInFolder(leaf?.view?.file)) {
+    if (leaf.view && leaf.view.file) {
       lastContactLeaf = leaf;
       scrollToLeaf(lastContactLeaf);
     }
@@ -29,6 +29,7 @@ const scrollToLeaf = (leaf: WorkspaceLeaf):void => {
 	clearTimeout(debounceTimer); // Reset debounce timer
   debounceTimer = window.setTimeout(() => {
 		if (!(leaf?.view instanceof MarkdownView)) return;
+        if (leaf.view.file === null) return;
 
 		const contactElement = document.getElementById(fileId(leaf.view.file));
 		if (!contactElement) return;


### PR DESCRIPTION
This pull request addresses Bug #7, where users could enter invalid or misformatted folder paths in the Contacts folder setting.

-     Replaces manual input with a folder selector using addSearch and FolderSuggest
-     Strips trailing slashes and quotes from the selected path
-     Adds a reactive onSettingsChange system to immediately update the UI on setting changes
-     Allows the base path to be the root of the vault (TBD if this is wise...)

