### PR TITLE
Fix #11: Add "Make contacts folder" button for new users

### DIFF
--- a/src/ui/sidebar/components/SidebarRootView.tsx
+++ b/src/ui/sidebar/components/SidebarRootView.tsx
@@ -133,28 +133,52 @@ export const SidebarRootView = () => {
           </div>
         </div>
         <div className="contacts-view">
-          <ContactsListView
-            contacts={contacts}
-            sort={sort}
-            processAvatar={(contact :Contact) => {
-              (async () => {
-                try {
-                  await processAvatar(contact);
-                  setTimeout(() => { parseContacts() }, 50);
-                } catch (err) {
-                  new Notice(err.message);
-                }
-              })();
-            }}
-            exportVCF={(contactFile: TFile) => {
-              (async () => {
-                const vcards = await vcardToString([contactFile])
-                saveVcardFilePicker(vcards, contactFile)
-              })();
-            }} />
+          { contacts.length > 0 ?
+            <ContactsListView
+              contacts={contacts}
+              sort={sort}
+              processAvatar={(contact :Contact) => {
+                (async () => {
+                  try {
+                    await processAvatar(contact);
+                    setTimeout(() => { parseContacts() }, 50);
+                  } catch (err) {
+                    new Notice(err.message);
+                  }
+                })();
+              }}
+              exportVCF={(contactFile: TFile) => {
+                (async () => {
+                  const vcards = await vcardToString([contactFile])
+                  saveVcardFilePicker(vcards, contactFile)
+                })();
+              }} />
+          :
+            <>
+              <div className="action-card">
+                <div className="action-card-content">
+                  <p>Your contacts folder is currently set to the <strong>root of your vault</strong>.</p>
+                  <p>We advise to create a specific folder prevent system processing</p>
+                  <button className="action-card-button"
+                  >Make contacts folder
+                  </button>
+                </div>
+              </div>
+
+              <div className="action-card">
+                <div className="action-card-content">
+                  <p><b>No contacts found</b> It looks like you haven’t added any contacts yet. Use the icons above to:</p>
+                  <ul>
+                    <li>Create a new contact manually</li>
+                    <li>Import a <code>.vcf</code> file from another app</li>
+                  </ul>
+                </div>
+              </div>
+            </>
+          }
         </div>
-      </>
-    }
-  </div>
-	);
+        </>
+      }
+    </div>
+  );
 };

--- a/src/ui/sidebar/components/SidebarRootView.tsx
+++ b/src/ui/sidebar/components/SidebarRootView.tsx
@@ -18,14 +18,17 @@ import { processAvatar } from "src/util/avatarActions";
 import { Sort } from "src/util/constants";
 import myScrollTo from "src/util/myScrollTo";
 
-export const SidebarRootView = () => {
+interface SidebarRootViewProps {
+  createDefaultPluginFolder: () => Promise<void>;
+}
+
+export const SidebarRootView = (props: SidebarRootViewProps) => {
 	const app = getApp();
   const { vault, workspace } = app;
-
   const [contacts, setContacts] = React.useState<Contact[]>([]);
   const [displayInsightsView, setDisplayInsightsView] = React.useState<boolean>(false);
 	const [sort, setSort] = React.useState<Sort>(Sort.NAME);
-	const settings = getSettings();
+	let settings = getSettings();
 
 	const parseContacts = () => {
 		const contactsFolder = vault.getAbstractFileByPath(
@@ -44,7 +47,10 @@ export const SidebarRootView = () => {
 
 	React.useEffect(() => {
 		parseContacts();
-    const offSettings = onSettingsChange(parseContacts.bind(this));
+    const offSettings = onSettingsChange(() => {
+      settings = getSettings();
+      parseContacts.call(this);
+    });
 
     return () => {
       offSettings();
@@ -155,15 +161,18 @@ export const SidebarRootView = () => {
               }} />
           :
             <>
-              <div className="action-card">
-                <div className="action-card-content">
-                  <p>Your contacts folder is currently set to the <strong>root of your vault</strong>.</p>
-                  <p>We advise to create a specific folder prevent system processing</p>
-                  <button className="action-card-button"
-                  >Make contacts folder
-                  </button>
+              {!settings.contactsFolder ?
+                <div className="action-card">
+                  <div className="action-card-content">
+                    <p>
+                      Your contacts folder is currently set to the <strong>root of your vault</strong>. We advise to create a specific folder prevent system processing.
+                    </p>
+                    <p>
+                      <button onClick={props.createDefaultPluginFolder} className="action-card-button">Make contacts folder</button>
+                    </p>
+                  </div>
                 </div>
-              </div>
+              : null }
 
               <div className="action-card">
                 <div className="action-card-content">

--- a/src/ui/sidebar/sidebarView.tsx
+++ b/src/ui/sidebar/sidebarView.tsx
@@ -1,4 +1,4 @@
-import { ItemView, WorkspaceLeaf } from "obsidian";
+import { ItemView, Notice, WorkspaceLeaf } from "obsidian";
 import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { clearApp, setApp } from "src/context/sharedAppContext";
@@ -15,6 +15,28 @@ export class ContactsView extends ItemView {
 		super(leaf);
 		this.plugin = plugin;
 	}
+
+  async createDefaultPluginFolder(): Promise<void> {
+    const vault = this.app.vault;
+    const folderPath = "Contacts"; // You can move this to a constant if you prefer
+
+    try {
+      const folderExists = await vault.adapter.exists(folderPath);
+      if (!folderExists) {
+        await vault.createFolder(folderPath);
+        this.plugin.settings.contactsFolder = folderPath;
+        await this.plugin.saveSettings();
+        setSettings(this.plugin.settings);
+      } else {
+        this.plugin.settings.contactsFolder = folderPath;
+        await this.plugin.saveSettings();
+        setSettings(this.plugin.settings);
+      }
+    } catch (err) {
+      new Notice('Failed to create folder default Contacts folder');
+    }
+  }
+
 	getViewType(): string {
 		return CONTACTS_VIEW_CONFIG.type;
 	}
@@ -31,7 +53,9 @@ export class ContactsView extends ItemView {
 		setApp(this.app);
     setSettings(this.plugin.settings);
 		this.root.render(
-				<SidebarRootView />
+				<SidebarRootView
+          createDefaultPluginFolder={this.createDefaultPluginFolder.bind(this)}
+        />
 		);
 	}
 


### PR DESCRIPTION
This update improves the new user experience by introducing a "Make contacts folder" button directly in the UI when the contacts folder is set to the root and there are no contact md files. Also some hints are provided for importing

![image](https://github.com/user-attachments/assets/82860a23-51e7-4994-a8b0-a539d3298fb0)
