### PR TITLE
feat: Add watch mode for development builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,23 @@ Start using the plugin today and share your experience in the [💬 GitHub Discu
 
 ---
 
+## 🔧 Development
+
+For plugin development:
+```bash
+# Install dependencies
+npm install
+
+# Build the plugin
+npm run build
+
+# Development build
+npm run dev
+npm run dev watch   # with auto-rebuild on changes
+```
+
+---
+
 ## 📘 Testing strategy
 Our goal is to maintain high-confidence, non-UI testing that focuses on:
 * Validating all resolved production bugs.

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -10,35 +10,41 @@ if you want to view the source, please visit the github repository of this plugi
 
 const prod = process.argv[2] === "production";
 
-esbuild
-  .build({
-    banner: {
-      js: banner,
-    },
-    entryPoints: ["src/main.ts"],
-    bundle: true,
-    external: [
-      "obsidian",
-      "electron",
-      "@codemirror/autocomplete",
-      "@codemirror/collab",
-      "@codemirror/commands",
-      "@codemirror/language",
-      "@codemirror/lint",
-      "@codemirror/search",
-      "@codemirror/state",
-      "@codemirror/view",
-      "@lezer/common",
-      "@lezer/highlight",
-      "@lezer/lr",
-      ...builtins,
-    ],
-    format: "cjs",
-    target: "es2022",
-    logLevel: "info",
-    sourcemap: prod ? false : "inline",
-    treeShaking: true,
-    minify: true,
-    outfile: "main.js",
-  })
-  .catch(() => process.exit(1));
+const ctx = await esbuild.context({
+  banner: {
+    js: banner,
+  },
+  entryPoints: ["src/main.ts"],
+  bundle: true,
+  external: [
+    "obsidian",
+    "electron",
+    "@codemirror/autocomplete",
+    "@codemirror/collab",
+    "@codemirror/commands",
+    "@codemirror/language",
+    "@codemirror/lint",
+    "@codemirror/search",
+    "@codemirror/state",
+    "@codemirror/view",
+    "@lezer/common",
+    "@lezer/highlight",
+    "@lezer/lr",
+    ...builtins,
+  ],
+  format: "cjs",
+  target: "es2022",
+  logLevel: "info",
+  sourcemap: prod ? false : "inline",
+  treeShaking: true,
+  minify: true,
+  outfile: "main.js",
+});
+
+if (process.argv[2] === "watch") {
+  await ctx.watch();
+  console.log("⚡ Watch mode enabled - rebuilding on file changes...");
+} else {
+  await ctx.rebuild();
+  await ctx.dispose();
+}


### PR DESCRIPTION
- Use esbuild context API for both watch and single builds
- Run with 'npm run dev watch' for watch mode
- Auto-rebuild on file changes during development
- Properly dispose context after single builds
- Add minimal development documentation to README

(Portions of this change were initially generated with Claude Code, but I reviewed, edited, and take full responsibility.)