### PR TITLE
feat: Add card menu with contact external links (#60)

### DIFF
--- a/src/contacts/contactDataKeys.ts
+++ b/src/contacts/contactDataKeys.ts
@@ -97,3 +97,13 @@ export function parseKey(input: string): ParsedKey {
 	const { key, index, type } = parseKeyPart(main);
 	return { key, index, type, subkey };
 }
+
+export function getSubkeyNameFallback(key: ParsedKey): String {
+	if (key.subkey != null && key.subkey.length > 0) {
+		return key.subkey;
+	} else if (key.type != null && key.type.length > 0){
+		return key.type;
+	} else {
+		return key.key;
+	}
+}

--- a/src/ui/sidebar/components/ContactView.tsx
+++ b/src/ui/sidebar/components/ContactView.tsx
@@ -1,6 +1,6 @@
-import { setIcon, TFile } from "obsidian";
+import { Menu, Notice, setIcon, TFile } from "obsidian";
 import * as React from "react";
-import { Contact, parseKey } from "src/contacts";
+import { Contact, getSubkeyNameFallback, parseKey } from "src/contacts";
 import { getApp } from "src/context/sharedAppContext";
 import { fileId, openFile } from "src/file/file";
 import Avatar from "src/ui/sidebar/components/Avatar";
@@ -159,6 +159,21 @@ export const ContactView = (props: ContactProps) => {
 		return null;
 	};
 
+	const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+		event.preventDefault();
+		const menu = new Menu();
+		for (const [key, value] of Object.entries(contact.data)) {
+			if ((key.startsWith("URL") || key.startsWith("SOCIALPROFILE")) && value.length > 0) {
+				menu.addItem((item) => {
+					const keyParsed = parseKey(key);
+					const keyName = getSubkeyNameFallback(keyParsed);
+					item.setTitle(`Open ${keyName.toLowerCase()}`).onClick(() => window.open(value, "_blank"))
+				});
+			}
+		}
+		menu.showAtPosition({ x: event.pageX, y: event.pageY });
+	}
+
 	return (
 		<div
 			className="contact-card"
@@ -167,7 +182,7 @@ export const ContactView = (props: ContactProps) => {
 		>
 			<div className="content">
 				<div className="inner-card-container">
-					<div className="bizzy-card-container">
+					<div className="bizzy-card-container"  onContextMenu={handleContextMenu}>
 						{renderOrganization(contact.data)}
 						<div className="biz-card-a">
 							<div className="biz-headshot biz-pic-drew">


### PR DESCRIPTION
Add card menu with account links, now supports non empty `URL` and `SOCIALPROFILE` keys