### PR TITLE
Add alternative encodings support

### DIFF
--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -95,44 +95,188 @@ export function fileJoin(...parts: string[]): string {
 }
 
 export async function openFilePicker(type: string): Promise<string | Blob> {
-	return new Promise((resolve) => {
-		const input = document.createElement("input");
-		input.type = "file";
-		input.accept = type;
-		input.style.display = "none";
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = type;
+    input.style.display = "none";
 
-		input.addEventListener("change", () => {
-			if (input?.files && input.files.length > 0) {
-				const file = input.files[0];
+    input.addEventListener("change", async () => {
+      if (input?.files && input.files.length > 0) {
+        const file = input.files[0];
 
-				const isImage = type === 'image/*' || type.startsWith('image/');
-				if (isImage) {
-					resolve(file); // Return the File for image use
-				} else {
-					const reader = new FileReader();
+        const isImage = type === "image/*" || type.startsWith("image/");
+        if (isImage) {
+          resolve(file); // Return the File for image use
+        } else {
+          try {
+            // Prefer raw bytes so we can detect encoding
+            const buffer = await file.arrayBuffer();
+            const bytes = new Uint8Array(buffer);
 
-					reader.onload = function (event) {
-						const rawData = event?.target?.result || '';
-						if (typeof rawData === "string") {
-							resolve(rawData);
-						} else {
-							resolve(new TextDecoder("utf-8").decode(rawData));
-						}
-					};
+            const encoding = detectVCardEncoding(bytes);
+            const decoder = new TextDecoder(encoding as any, { fatal: false });
+            let text = decoder.decode(bytes);
 
-					reader.readAsText(file, "UTF-8");
-				}
-			} else {
-				resolve('');
-			}
-		});
+            // Optionally strip leading BOM char if present after decode
+            if (text.charCodeAt(0) === 0xfeff) {
+              text = text.slice(1);
+            }
 
-		document.body.appendChild(input);
-		input.click();
-		document.body.removeChild(input);
-	});
+            resolve(text);
+          } catch (e) {
+            // Fallback to UTF-8 text if anything goes wrong
+            const reader = new FileReader();
+            reader.onload = function (event) {
+              const rawData = event?.target?.result || "";
+              if (typeof rawData === "string") {
+                resolve(rawData);
+              } else {
+                resolve(new TextDecoder("utf-8").decode(rawData as ArrayBuffer));
+              }
+            };
+            reader.readAsText(file, "UTF-8");
+          }
+        }
+      } else {
+        resolve("");
+      }
+    });
+
+    document.body.appendChild(input);
+    input.click();
+    document.body.removeChild(input);
+  });
 }
 
+/**
+ * Best-effort encoding detection for vCard files.
+ * Strategy:
+ * 1) BOM
+ * 2) Valid UTF-8 heuristic
+ * 3) CHARSET=... token in vCard (v2.1/3.0)
+ * 4) Fallback to windows-1252
+ */
+function detectVCardEncoding(bytes: Uint8Array): string {
+  const bom = detectBom(bytes);
+  if (bom) return bom;
+
+  if (isLikelyUtf8(bytes)) return "utf-8";
+
+  const charset = detectVCardCharsetToken(bytes);
+  if (charset) return normalizeEncodingLabel(charset);
+
+  // Common legacy default for Western vCards
+  return "windows-1252";
+}
+
+function detectBom(bytes: Uint8Array): string | null {
+  if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    return "utf-8";
+  }
+  if (bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xfe) {
+    // Could be UTF-16LE or UTF-32LE if next two are 0x00 0x00
+    if (bytes.length >= 4 && bytes[2] === 0x00 && bytes[3] === 0x00) return "utf-32le";
+    return "utf-16le";
+  }
+  if (bytes.length >= 2 && bytes[0] === 0xfe && bytes[1] === 0xff) {
+    return "utf-16be";
+  }
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x00 &&
+    bytes[1] === 0x00 &&
+    bytes[2] === 0xfe &&
+    bytes[3] === 0xff
+  ) {
+    return "utf-32be";
+  }
+  return null;
+}
+
+// Simple UTF-8 validator (not perfect, but good heuristic)
+function isLikelyUtf8(bytes: Uint8Array): boolean {
+  let i = 0;
+  while (i < bytes.length) {
+    const b = bytes[i++];
+    if (b <= 0x7f) continue; // ASCII
+
+    let n = 0;
+    if (b >= 0xc2 && b <= 0xdf) n = 1; // 2-byte
+    else if (b >= 0xe0 && b <= 0xef) n = 2; // 3-byte
+    else if (b >= 0xf0 && b <= 0xf4) n = 3; // 4-byte
+    else return false;
+
+    for (let j = 0; j < n; j++) {
+      if (i >= bytes.length) return false;
+      const c = bytes[i++];
+      if ((c & 0xc0) !== 0x80) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Try to locate a vCard CHARSET=... token using only ASCII matching.
+ * Example: N;CHARSET=ISO-8859-1:...
+ */
+function detectVCardCharsetToken(bytes: Uint8Array): string | null {
+  // Build ASCII-only string to safely search tokens without decoding
+  let ascii = "";
+  const limit = Math.min(bytes.length, 64 * 1024); // scan up to 64KB
+  for (let i = 0; i < limit; i++) {
+    const b = bytes[i];
+    ascii += b < 0x80 ? String.fromCharCode(b) : ".";
+  }
+
+  const idx = ascii.toUpperCase().indexOf("CHARSET=");
+  if (idx === -1) return null;
+
+  // Extract token until a separator (; , : \n \r)
+  const start = idx + "CHARSET=".length;
+  let end = start;
+  while (
+    end < ascii.length &&
+    ![";", ",", ":", "\n", "\r"].includes(ascii[end])
+  ) {
+    end++;
+  }
+
+  const raw = ascii.slice(start, end).trim();
+  if (!raw) return null;
+  return raw;
+}
+
+/**
+ * Map common charset tokens to WHATWG/TextDecoder labels.
+ */
+function normalizeEncodingLabel(label: string): string {
+  const lower = label.toLowerCase();
+
+  // Common synonyms
+  if (lower === "utf8" || lower === "utf-8") return "utf-8";
+  if (lower === "utf-16" || lower === "utf16") return "utf-16le"; // ambiguous; most files are LE on Windows
+  if (lower === "utf-16le" || lower === "utf16le") return "utf-16le";
+  if (lower === "utf-16be" || lower === "utf16be") return "utf-16be";
+
+  if (lower === "latin1" || lower === "iso8859-1" || lower === "iso_8859-1" || lower === "iso-8859-1")
+    return "iso-8859-1";
+
+  if (lower === "cp1252" || lower === "windows-1252" || lower === "windows1252")
+    return "windows-1252";
+
+  if (lower === "shift-jis" || lower === "shift_jis" || lower === "sjis")
+    return "shift_jis";
+
+  if (lower === "gbk") return "gbk";
+  if (lower === "gb2312") return "gb2312";
+  if (lower === "big5") return "big5";
+  if (lower === "euc-kr" || lower === "euc_kr") return "euc-kr";
+  if (lower === "windows-1251" || lower === "cp1251") return "windows-1251";
+
+  // Let TextDecoder try the provided label if it's valid
+  return lower;
+}
 
 export function saveVcardFilePicker(data: string, obsidianFile?: TFile ) {
   try {


### PR DESCRIPTION
Hi! Thanks for this great plugin!

Unfortunatelly, it does not support the charset other than UTF-8 (which was allowed in previous vCard standarts).
Exactly this case - v2.1 with windows-1251 encoding - is used in my company's internal contact reference service, so it's painful to add a new card with manual re-encoding beforehand.

This PR aims to bring alternative encodings support without breaking backward compatibility. 
I've tested both utf-8 and non utf-8 files locally, plus all th tests pass.

I've added a new function `detectVCardEncoding` that determines the most likely encoding of a vCard file using BOM detection, UTF-8 heuristics, and searching for a `CHARSET=` token (our case), with a fallback to UTF-8 if anything goes wrong.

