### PR TITLE
Don't bail update when encountering UID, PHOTO or an empty value

### DIFF
--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -141,7 +141,7 @@ export async function updateFromRemote(contact: Contact) {
         for (const [key, value] of Object.entries(remoteVcf.value?.[1])) {
 
           if (key === 'UID') {
-            break;
+            continue;
           }
 
           const localValue = contact.data[key];
@@ -150,12 +150,12 @@ export async function updateFromRemote(contact: Contact) {
             if(!localValue || localValue=== '') {
               await updateFrontMatterValue(contact.file, key, value);
             }
-            break;
+            continue;
           }
 
           if (!localValue || localValue === '') {
             await updateFrontMatterValue(contact.file, key, value);
-            break;
+            continue;
           }
 
           if(value.length !== 0 && localValue !== value) {


### PR DESCRIPTION
The break statement broke out of the loop completely. Due to this behavior only fields which were defined before one of the mentioned fields was update.

In my case this meant that VERSION would be updated, but UID was the second field and the rest wouldn't update after selected 'Pull' from the dropdown menu.